### PR TITLE
chore(deps): support Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "fmtod/laravel-tabulator": "*",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "inertiajs/inertia-laravel": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Part of the Laravel 13 upgrade — parent PR: https://github.com/FmTod/mylisterhub-main-app/pull/3544

**Merge this before the parent**, which points its `modules/tabulator-inertia` submodule at this branch.

## Changes

- add `^13.0` to the `illuminate/*` constraints so the package installs alongside Laravel 13 (existing majors are appended to, not replaced)

## Verification

Verified as part of the parent upgrade: the application resolves and boots on Laravel 13.23.0 with this branch installed. A three-directory test sweep was compared against a Laravel 12 baseline and the failure sets were identical, so the upgrade introduced no regressions.

Note this package's own `require-dev` still caps `orchestra/testbench` at Laravel 10/11, so its CI cannot yet exercise the `^13` constraint. Widening the dev toolchain is deliberately out of scope here.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Laravel 13 support to `illuminate/contracts` dependency constraint
> Adds `^13.0` to the version constraint for `illuminate/contracts` in [composer.json](https://github.com/FmTod/laravel-tabulator-inertia/pull/46/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34), allowing the package to be installed alongside Laravel 13.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cf9dbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->